### PR TITLE
[FIX] Hide information in startup message.

### DIFF
--- a/app/scripts/scenes/game.js
+++ b/app/scripts/scenes/game.js
@@ -109,7 +109,7 @@ export default class Game extends Phaser.Scene {
               })),
               apples: self.apples.getGridLocation()
             };
-            agent.socket.send(JSON.stringify(msg));
+            agent.socket.send(self.personalize(JSON.stringify(msg), agent));
 
             // Listen for further messages from the agens
             agent.socket.addEventListener('message', (agent => function (event) {


### PR DESCRIPTION
Hides the locations of the other agents and the apples that are outside of the
15x15 neighborhood window in the startup message.